### PR TITLE
demo CLV estimates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
 
+Changes in version 0.x.x (20xx-xx-xx):
+
+    o   `elog2cbs` now returns sum over sales for calibration and holdout period
+
+    o   enhanced CDNow demo with estimating of monetary component (i.e. CLV estimate)
+
 Changes in version 0.7.0 (2016-04-19):
 
     o   ggnbd.ConditionalExpectedTransactions disabled

--- a/R/elog2cbs.R
+++ b/R/elog2cbs.R
@@ -7,42 +7,71 @@
 #'      t.x:    time between first and last event in calibration period
 #'      litt:   sum of logarithmic intertransaction timings durint calibration period 
 #'              this is a summary statistic for estimating regularity
+#'      sales:  sum of sales in calibration period
+#'      first:  date of first transaction in calibration period
 #'      T.cal:  time between first event and end of calibration period
 #'      T.star: length of holdout period
 #'      x.star: nr of events within holdout period
+#'      sales.star: sum of sales within holdout period
+#'      
+#' Customers without any transaction during calibration period are being dropped from the result.
+#' Transactions with identical `cust` and `date` field are treated as a single transaction, with `sales` being summed up
 #'
-#' @param elog data.frame with columns 'cust' and 'date'
+#' @param elog data.frame with columns 'cust' and 'date'; optionally with column 'sales'
 #' @param per time unit, either 'week', 'day', 'hour', 'min', 'sec'
 #' @param T.cal end date of calibration period
 #' @param T.tot end date of holdout period
 #' @return data.frame
 #' @export
 elog2cbs <- function(elog, per = "week", T.cal = max(elog$date), T.tot = max(elog$date)) {
-  cust <- first <- itt <- T.star <- x.star <- NULL  # avoid checkUsage warnings
+  cust <- first <- itt <- T.star <- x.star <- sales <- sales.star <- NULL  # avoid checkUsage warnings
+  stopifnot(inherits(elog, "data.frame"))
+  stopifnot(all(c("cust", "date") %in% names(elog)))
+  stopifnot(any(c("Date", "POSIXt") %in% class(elog$date)))
   
   is.dt <- is.data.table(elog)
+  has.sales <- "sales" %in% names(elog)
   # convert to data.table for improved performance
   elog_dt <- data.table(elog)
-  # merge same dates
   setkey(elog_dt, cust, date)
-  elog_dt <- unique(elog_dt)
+  # check for `sales` column, and populate if missing
+  if (!has.sales) {
+    elog_dt[, sales := 1.0]
+  } else {
+    stopifnot(is.numeric(elog_dt$sales))
+  }
+  # merge transactions with same dates
+  elog_dt <- elog_dt[, list(sales = sum(sales)), by = "cust,date"]
   # determine time since first date for each customer
   elog_dt[, `:=`(first, min(date)), by = "cust"]
   elog_dt[, `:=`(t, as.numeric(difftime(date, first, units = per))), by = "cust"]
   # compute intertransaction times
   elog_dt[, `:=`(itt, c(0, diff(t))), by = "cust"]
   # count events in calibration period
-  cbs <- elog_dt[date <= T.cal, list(x = .N - 1, t.x = max(t), litt = sum(log(itt[itt > 0]))), by = "cust,first"]
+  cbs <- elog_dt[date <= T.cal, 
+                 list(x = .N - 1, 
+                      t.x = max(t), 
+                      litt = sum(log(itt[itt > 0])),
+                      sales = sum(sales)),
+                 by = "cust,first"]
   cbs[, `:=`(T.cal, as.numeric(difftime(T.cal, first, units = per)))]
   cbs[, `:=`(T.star, as.numeric(difftime(T.tot, first, units = per)) - T.cal)]
-  cbs[, `:=`(first, NULL)]
   setkey(cbs, cust)
   # count events in validation period
-  val <- elog_dt[date > T.cal & date <= T.tot, list(x.star = .N), keyby = "cust"]
+  val <- elog_dt[date > T.cal & date <= T.tot, 
+                 list(x.star = .N,
+                      sales.star = sum(sales)), 
+                 keyby = "cust"]
   cbs <- merge(cbs, val, all.x = TRUE, by = "cust")
   cbs[is.na(x.star), `:=`(x.star, 0)]
+  cbs[is.na(sales.star), `:=`(sales.star, 0)]
+  setcolorder(cbs, c("cust", "x", "t.x", "litt", "sales", "first", "T.cal", "T.star", "x.star", "sales.star"))
   # return same object type as was passed
-  if (!is.dt) 
+  if (!has.sales) {
+    elog_dt[, `:=`(sales, NULL)]
+  }
+  if (!is.dt) {
     cbs <- data.frame(cbs)
+  }
   return(cbs)
 } 

--- a/man/elog2cbs.Rd
+++ b/man/elog2cbs.Rd
@@ -8,7 +8,7 @@ elog2cbs(elog, per = "week", T.cal = max(elog$date),
   T.tot = max(elog$date))
 }
 \arguments{
-\item{elog}{data.frame with columns 'cust' and 'date'}
+\item{elog}{data.frame with columns 'cust' and 'date'; optionally with column 'sales'}
 
 \item{per}{time unit, either 'week', 'day', 'hour', 'min', 'sec'}
 
@@ -26,8 +26,14 @@ Returns data.frame with
      t.x:    time between first and last event in calibration period
      litt:   sum of logarithmic intertransaction timings durint calibration period 
              this is a summary statistic for estimating regularity
+     sales:  sum of sales in calibration period
+     first:  date of first transaction in calibration period
      T.cal:  time between first event and end of calibration period
      T.star: length of holdout period
      x.star: nr of events within holdout period
+     sales.star: sum of sales within holdout period
+     
+Customers without any transaction during calibration period are being dropped from the result.
+Transactions with identical `cust` and `date` field are treated as a single transaction, with `sales` being summed up
 }
 

--- a/tests/testthat/test-elog2cbs.R
+++ b/tests/testthat/test-elog2cbs.R
@@ -1,0 +1,44 @@
+context("elog2cbs")
+
+test_that("elog2cbs", {
+  cat('test elog2cbs')
+  
+  elog <- data.frame(cust = c(1, 1, 1, 1, 1, 2, 3), date = Sys.Date() + c(0, 14, 14, 28, 35, 7, 24))
+  elog_dt <- as.data.table(elog)
+  elog_dt[, first := min(date), by="cust"]
+  elog_s <- copy(elog_dt)
+  elog_s[, sales := .I]
+  T.cal <- Sys.Date() + 21
+  T.tot <- Sys.Date() + 30
+  
+  # check that the return type matches the input type
+  expect_is(elog2cbs(elog), "data.frame")
+  expect_is(elog2cbs(elog_dt), "data.table")
+
+  # check column names
+  cols <- c("cust", "x", "t.x", "litt", "sales", "first", "T.cal", "T.star", "x.star", "sales.star")
+  expect_named(elog2cbs(elog), cols)
+  expect_named(elog2cbs(elog, T.cal = T.cal), cols)
+  expect_named(elog2cbs(elog, T.cal = T.cal, T.tot = T.tot), cols)
+  expect_named(elog2cbs(elog_s), cols)
+  expect_named(elog2cbs(elog_dt), cols)
+  
+  # check number of returned customers
+  expect_equal(uniqueN(elog$cust), nrow(elog2cbs(elog)))
+  expect_equal(uniqueN(elog[elog$date <= T.cal, "cust"]), nrow(elog2cbs(elog, T.cal = T.cal)))
+
+  # check total number of transactions
+  cbs <- elog2cbs(elog_dt)
+  expect_equal(uniqueN(elog_dt[, .(cust, date)]), sum(cbs$x) + sum(cbs$x.star) + nrow(cbs))
+  expect_true(all(cbs$T.star == 0))
+  expect_true(all(cbs$x.star == 0))
+  expect_true(all(cbs$sales.star == 0))
+  cbs <- elog2cbs(elog_dt, T.cal = T.cal, T.tot = T.tot)
+  expect_equal(uniqueN(elog_dt[elog_dt$first <= T.cal & date <= T.tot, .(cust, date)]), 
+               sum(cbs$x) + sum(cbs$x.star) + nrow(cbs))
+
+  # check sales
+  cbs <- elog2cbs(elog_s, T.cal = T.cal, T.tot = T.tot)
+  expect_equal(elog_s[first <= T.cal & date <= T.cal, sum(sales)], sum(cbs$sales))
+  expect_equal(elog_s[first <= T.cal & date <= T.tot, sum(sales)], sum(cbs$sales) + sum(cbs$sales.star))
+})


### PR DESCRIPTION
* `elog2cbs` now returns sum over sales for calibration and holdout period
* enhanced CDNow demo with estimating of monetary component (i.e. CLV estimate)
* added tests for `elog2cbs`

fixes #15