### PR TITLE
Fix compatibility with BTYD 2.4+

### DIFF
--- a/R/pareto-ggg-mcmc.R
+++ b/R/pareto-ggg-mcmc.R
@@ -202,9 +202,12 @@ pggg.mcmc.DrawParameters <- function(cal.cbs, mcmc = 2500, burnin = 500, thin = 
   if (is.null(param_init)) {
     try({
         df <- cal.cbs[sample(nrow(cal.cbs), min(nrow(cal.cbs), 1000)), ]
-        param_init <- c(1, 1, BTYD::pnbd.EstimateParameters(df))
-        names(param_init) <- c("t", "gamma", "r", "alpha", "s", "beta")
-        param_init <- as.list(param_init)
+        est <- BTYD::pnbd.EstimateParameters(df[, c("x", "t.x", "T.cal")])
+        if (all(is.finite(est))) {
+          param_init <- c(1, 1, est)
+          names(param_init) <- c("t", "gamma", "r", "alpha", "s", "beta")
+          param_init <- as.list(param_init)
+        }
       },
       silent = TRUE)
     if (is.null(param_init))

--- a/R/pareto-nbd-mcmc.R
+++ b/R/pareto-nbd-mcmc.R
@@ -192,9 +192,12 @@ pnbd.mcmc.DrawParameters <- function(cal.cbs, mcmc = 2500, burnin = 500, thin = 
   if (is.null(param_init)) {
     try({
         df <- cal.cbs[sample(nrow(cal.cbs), min(nrow(cal.cbs), 1000)), ]
-        param_init <- BTYD::pnbd.EstimateParameters(df)
-        names(param_init) <- c("r", "alpha", "s", "beta")
-        param_init <- as.list(param_init)
+        est <- BTYD::pnbd.EstimateParameters(df[, c("x", "t.x", "T.cal")])
+        if (all(is.finite(est))) {
+          param_init <- est
+          names(param_init) <- c("r", "alpha", "s", "beta")
+          param_init <- as.list(param_init)
+        }
       },
       silent = TRUE)
     if (is.null(param_init))

--- a/demo/cdnow.R
+++ b/demo/cdnow.R
@@ -62,11 +62,11 @@ mean(cbs$palive.mbgcnbd)
 
 x <- readline("Compare Log-Likelihoods of various models (press Enter)")
 
-params.pnbd <- BTYD::pnbd.EstimateParameters(cbs) # estimate Pareto/NBD
+params.pnbd <- BTYD::pnbd.EstimateParameters(cbs[, c("x", "t.x", "T.cal")]) # estimate Pareto/NBD
 params.bgcnbd <- bgcnbd.EstimateParameters(cbs)  # estimate BG/CNBD-k
 
 (ll <- c(`NBD`        = nbd.cbs.LL(params.nbd, cbs),
-        `Pareto/NBD` = BTYD::pnbd.cbs.LL(params.pnbd, cbs),
+        `Pareto/NBD` = BTYD::pnbd.cbs.LL(params.pnbd, cbs[, c("x", "t.x", "T.cal")]),
         `BG/CNBD-k`  = bgcnbd.cbs.LL(params.bgcnbd, cbs),
         `MBG/CNBD-k` = mbgcnbd.cbs.LL(params.mbgcnbd, cbs)))
 names(which.max(ll))
@@ -86,7 +86,7 @@ x <- readline("Plot Incremental Transactions (press Enter)")
 inc <- elog2inc(cdnowElog)
 op <- par(mfrow = c(1, 2))
 nil <- mbgcnbd.PlotTrackingInc(params.mbgcnbd, cbs$T.cal, T.tot = 78, inc, title = "MBG/CNBD-k")
-nil <- BTYD::pnbd.PlotTrackingInc(params.pnbd, cbs$T.cal, T.tot = 78, inc, title = "Pareto/NBD")
+nil <- BTYD::pnbd.PlotTrackingInc(params.pnbd, cbs$T.cal, T.tot = 78, inc, n.periods.final = length(inc), title = "Pareto/NBD")
 par(op)
 
 

--- a/demo/mbg-cnbd-k.R
+++ b/demo/mbg-cnbd-k.R
@@ -49,12 +49,12 @@ mean(cbs$palive.mbgcnbd)
 x <- readline("Compare log-likelihoods of various models (press Enter)")
 
 params.nbd <- nbd.EstimateParameters(cbs)            # estimate NBD
-params.pnbd <- BTYD::pnbd.EstimateParameters(cbs)    # estimate Pareto/NBD
+params.pnbd <- BTYD::pnbd.EstimateParameters(cbs[, c("x", "t.x", "T.cal")])    # estimate Pareto/NBD
 params.bgnbd <- BTYD::bgnbd.EstimateParameters(cbs)  # estimate BG/NBD
 params.mbgnbd <- mbgnbd.EstimateParameters(cbs)      # estimate MBG/NBD
 
 (ll <- c(`NBD`        = nbd.cbs.LL(params.nbd, cbs),
-         `Pareto/NBD` = BTYD::pnbd.cbs.LL(params.pnbd, cbs),
+         `Pareto/NBD` = BTYD::pnbd.cbs.LL(params.pnbd, cbs[, c("x", "t.x", "T.cal")]),
          `BG/NBD`     = BTYD::bgnbd.cbs.LL(params.bgnbd, cbs),
          `MBG/NBD`    = mbgcnbd.cbs.LL(params.mbgnbd, cbs),
          `MBG/CNBD-k` = mbgcnbd.cbs.LL(params.mbgcnbd, cbs)))
@@ -107,5 +107,5 @@ inc <- elog2inc(groceryElog)
 T.tot <- max(cbs$T.cal+cbs$T.star)
 op <- par(mfrow = c(1, 2))
 nil <- mbgcnbd.PlotTrackingInc(params.mbgcnbd, cbs$T.cal, T.tot = T.tot, inc, title = "MBG/CNBD-k")
-nil <- BTYD::pnbd.PlotTrackingInc(params.pnbd, cbs$T.cal, T.tot = T.tot, inc, title = "Pareto/NBD")
+nil <- BTYD::pnbd.PlotTrackingInc(params.pnbd, cbs$T.cal, T.tot = T.tot, inc, n.periods.final = length(inc), title = "Pareto/NBD")
 par(op)

--- a/demo/pareto-ggg.R
+++ b/demo/pareto-ggg.R
@@ -23,7 +23,7 @@ pggg.draws <- pggg.mcmc.DrawParameters(cal.cbs = cbs,
 
 round(rbind(`Pareto/GGG`= summary(pggg.draws$level_2)$quantiles[, "50%"],
       `Pareto/NBD (HB)` = c(NA, NA, summary(pnbd.draws$level_2)$quantiles[, "50%"]),
-      `Pareto/NBD`      = c(NA, NA, BTYD::pnbd.EstimateParameters(cbs))), 2)
+      `Pareto/NBD`      = c(NA, NA, BTYD::pnbd.EstimateParameters(cbs[, c("x", "t.x", "T.cal")]))), 2)
 
 #' plot estimated parameter distributions
 plot(pggg.draws$level_2, density = TRUE, trace = FALSE)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // slice_sample_gamma_parameters
 NumericVector slice_sample_gamma_parameters(NumericVector data, NumericVector init, NumericVector hyper, double steps, double w);
 RcppExport SEXP _BTYDplus_slice_sample_gamma_parameters(SEXP dataSEXP, SEXP initSEXP, SEXP hyperSEXP, SEXP stepsSEXP, SEXP wSEXP) {


### PR DESCRIPTION
Subset CBS data frame columns to c('x', 't.x', 'T.cal') before passing to BTYD::pnbd functions, as BTYD 2.4+ strictly validates column names and order. Also explicitly pass n.periods.final to BTYD::pnbd.PlotTrackingInc in the demos to work around a validation bug in BTYD.